### PR TITLE
Change swift-syntax to swiftlang org

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the Swift 5.9 release of SwiftSyntax
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the Swift 5.9 release of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        // Depend on the Swift 5.9 release of SwiftSyntax
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "603.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import CompilerPluginSupport
 
 let package = Package(
     name: "HexColors",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13) ],
+    platforms: [.macOS(.v10_15), .iOS(.v17), .tvOS(.v17), .watchOS(.v6), .macCatalyst(.v17) ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/HexColorsMacros/HexColorsMacros.swift
+++ b/Sources/HexColorsMacros/HexColorsMacros.swift
@@ -42,7 +42,7 @@ public struct HexIntExpressionMacro: ExpressionMacro {
     
     public static func expansion(of node: some SwiftSyntax.FreestandingMacroExpansionSyntax, in context: some SwiftSyntaxMacros.MacroExpansionContext) throws -> SwiftSyntax.ExprSyntax {
         guard
-            let argument = node.argumentList.first?.expression,
+            let argument = node.arguments.first?.expression,
             let integerLiteral: TokenSyntax = argument.as(IntegerLiteralExprSyntax.self)?.literal
         else {
             fatalError("compiler bug: macro needs an integer literal")
@@ -79,7 +79,7 @@ extension HexExpressionMacro {
         in context: some SwiftSyntaxMacros.MacroExpansionContext
     ) throws -> SwiftSyntax.ExprSyntax {
     
-        guard let argument = node.argumentList.first?.expression else {
+        guard let argument = node.arguments.first?.expression else {
             fatalError("compiler bug: macro needs one argument")
         }
         


### PR DESCRIPTION
Apple has moved some of their Swift repos to a new GitHub organization 'swiftlang'

This change fixes warnings that will be future errors when multiple packages use the same repo from a different organization.